### PR TITLE
Fix lambda sequence for ridge (alpha = 0)

### DIFF
--- a/r-package/balnet/R/balnet.R
+++ b/r-package/balnet/R/balnet.R
@@ -33,8 +33,7 @@
 #' @param penalty.factor Penalty factor per feature. Default is 1 (i.e., each feature receives the same penalty).
 #' @param groups Optional list of group indices for group penalization.
 #' @param alpha Elastic net mixing parameter. Default is 1 (lasso), 0 corresponds to ridge.
-#' @param alpha Elastic net mixing parameter. Default is 1 (lasso), 0 corresponds to ridge.
-#'   For `alpha = 0`, the regularization path is constructed using a small positive value
+#'   For `alpha = 0`, the lambda sequence is constructed using a small positive `alpha` value
 #'   (similar to `glmnet`), since \eqn{\lambda_{max} \to \infty} as \eqn{\alpha \to 0}.
 #' @param standardize Whether to standardize the input matrix. Should only be `FALSE` if `X` already has
 #'   zero-mean columns with unit variance. For `target = "ATT"`, standardization should be based on the treated group.

--- a/r-package/balnet/R/balnet.R
+++ b/r-package/balnet/R/balnet.R
@@ -33,6 +33,9 @@
 #' @param penalty.factor Penalty factor per feature. Default is 1 (i.e., each feature receives the same penalty).
 #' @param groups Optional list of group indices for group penalization.
 #' @param alpha Elastic net mixing parameter. Default is 1 (lasso), 0 corresponds to ridge.
+#' @param alpha Elastic net mixing parameter. Default is 1 (lasso), 0 corresponds to ridge.
+#'   For `alpha = 0`, the regularization path is constructed using a small positive value
+#'   (similar to `glmnet`), since \eqn{\lambda_{max} \to \infty} as \eqn{\alpha \to 0}.
 #' @param standardize Whether to standardize the input matrix. Should only be `FALSE` if `X` already has
 #'   zero-mean columns with unit variance. For `target = "ATT"`, standardization should be based on the treated group.
 #' @param tol Coordinate descent convergence tolerance. Default is 1e-7.

--- a/r-package/balnet/R/balnet.fit.R
+++ b/r-package/balnet/R/balnet.fit.R
@@ -95,7 +95,7 @@ balnet.fit <- function(
     setup_lmda_path <- FALSE
     lmda_path_size <- length(lmda_path)
   }
-  lmda_max <- -1.0 # Let the solver compute this, is simply max(abs(crossprod(X, weights * (y / mean(y) - 1)))) (or of colMeans(X * y)), but does it faster
+  lmda_max <- -1.0 # Has easy closed-form solution, but let the solver compute this so path and non-zero beta solution line up exactly
   setup_lmda_max <- TRUE
 
   if (is.null(penalty)) {

--- a/r-package/balnet/R/balnet.fit.R
+++ b/r-package/balnet/R/balnet.fit.R
@@ -143,7 +143,9 @@ balnet.fit <- function(
 
   # Unused warm start options
   lmda <- Inf
-  screen_set <- (0:(groups$G-1))[(penalty <= 0) | (alpha <= 0)]
+  # adelie originally had a separate code path for ridge: `screen_set <- (0:(groups$G-1))[(penalty <= 0) | (alpha <= 0)]`
+  # but this causes issues with generating the lambda sequence, see https://github.com/erikcs/balnet/pull/38
+  screen_set <- (0:(groups$G-1))[(penalty <= 0)]
   screen_beta <- double(sum(groups$group_sizes[screen_set + 1]))
   screen_is_active <- as.integer(rep_len(1, length(screen_set)))
   active_set_size <- length(screen_set)

--- a/r-package/balnet/man/balnet.Rd
+++ b/r-package/balnet/man/balnet.Rd
@@ -50,7 +50,7 @@ and \code{lambda.min.ratio} (or \code{max.imbalance}, if specified).}
 \item{groups}{Optional list of group indices for group penalization.}
 
 \item{alpha}{Elastic net mixing parameter. Default is 1 (lasso), 0 corresponds to ridge.
-For \code{alpha = 0}, the regularization path is constructed using a small positive value
+For \code{alpha = 0}, the lambda sequence is constructed using a small positive \code{alpha} value
 (similar to \code{glmnet}), since \eqn{\lambda_{max} \to \infty} as \eqn{\alpha \to 0}.}
 
 \item{standardize}{Whether to standardize the input matrix. Should only be \code{FALSE} if \code{X} already has

--- a/r-package/balnet/man/balnet.Rd
+++ b/r-package/balnet/man/balnet.Rd
@@ -49,7 +49,9 @@ and \code{lambda.min.ratio} (or \code{max.imbalance}, if specified).}
 
 \item{groups}{Optional list of group indices for group penalization.}
 
-\item{alpha}{Elastic net mixing parameter. Default is 1 (lasso), 0 corresponds to ridge.}
+\item{alpha}{Elastic net mixing parameter. Default is 1 (lasso), 0 corresponds to ridge.
+For \code{alpha = 0}, the regularization path is constructed using a small positive value
+(similar to \code{glmnet}), since \eqn{\lambda_{max} \to \infty} as \eqn{\alpha \to 0}.}
 
 \item{standardize}{Whether to standardize the input matrix. Should only be \code{FALSE} if \code{X} already has
 zero-mean columns with unit variance. For \code{target = "ATT"}, standardization should be based on the treated group.}


### PR DESCRIPTION
when `alpha = 0` `adelie` currently initializes the gradient with everything active: [R](https://github.com/JamesYang007/adelie-r/blob/main/R/solver.R#L157C51-L157C59) / [Python](https://github.com/JamesYang007/adelie/blob/main/adelie/solver.py#L279)

This causes issue when generating the lambda sequence in [compute_lmda_max](https://github.com/JamesYang007/adelie/blob/main/adelie/src/include/adelie_core/solver/utils.hpp#L8): since `abs_grad` is then ~zero  (on the order of 1e-10 or smaller), the resulting`lmda_max` is tiny and doesn't give a meaningful path:

```R
> n <- 100
> p <- 25
> X <- matrix(rnorm(n * p), n, p)
> W <- rbinom(n, 1, 1 / (1 + exp(1 - X[, 1])))
> adelie::grpnet(X, adelie::glm.binomial(W), alpha = 0)

Call:  adelie::grpnet(X = X, glm = adelie::glm.binomial(W), alpha = 0) 

    Groups Df  %Dev    Lambda
1       25 25 54.06 2.845e-13
2       25 25 54.06 2.716e-13
3       25 25 54.06 2.592e-13
4       25 25 54.06 2.474e-13
...etc
```

**This PR**: Simply update the R binding to make the solver start at same non-zero gradient like it does for `alpha > 0` (can revisit in the future).

---

*Relatedly*, `compute_lmda_max` uses a ridge threshold in similar spirit as `glmnet` to avoid dividing by zero, but it doesn't clip values very close to zero:

```C++
    const auto factor = (alpha <= 0) ? ridge_scale : alpha;
```

I guess this would be more similar to what `glmnet` does (?):

```C++
    const auto factor = (alpha <= ridge_scale) ? ridge_scale : alpha;
```

Compared to `glmnet`:

```R
> n <- 100
> p <- 25
> X <- matrix(rnorm(n * p), n, p)
> W <- rbinom(n, 1, 1 / (1 + exp(1 - X[, 1])))
> adelie::grpnet(X, adelie::glm.binomial(W), alpha = 1e-5)

Call:  adelie::grpnet(X = X, glm = adelie::glm.binomial(W), alpha = 1e-05) 

    Groups Df %Dev  Lambda
1        1  1 0.00 16770.0
2        1  1 0.00 16010.0
3        1  1 0.00 15280.0
..etc

> glmnet::glmnet(X, W, family = "binomial", alpha = 1e-5)

Call:  glmnet::glmnet(x = X, y = W, family = "binomial", alpha = 1e-05) 

    Df  %Dev  Lambda
1    0  0.00 156.200
2   25  0.06 142.300
3   25  0.07 129.700
...
```

