### PR TITLE
Fix fold aggregation bug in cv.balnet

### DIFF
--- a/r-package/balnet/R/cv.balnet.R
+++ b/r-package/balnet/R/cv.balnet.R
@@ -76,12 +76,18 @@ cv.balnet <- function(
   idx.min0 <- idx.min1 <- NULL
   lambda.min0 <- lambda.min1 <- NULL
   if (!is.null(cv.list[[1]][["control"]])) {
-    cv.mean0 <- colMeans(matrix(unlist(lapply(cv.list, `[[`, "control")), nfolds, length(lambda.full$control)))
+    cv.mean0 <- colMeans(matrix(unlist(lapply(cv.list, `[[`, "control")),
+                                nrow = nfolds,
+                                ncol = length(lambda.full$control),
+                                byrow = TRUE))
     idx.min0 <- which.min(cv.mean0)
     lambda.min0 <- lambda.full[["control"]][idx.min0]
   }
   if (!is.null(cv.list[[1]][["treated"]])) {
-    cv.mean1 <- colMeans(matrix(unlist(lapply(cv.list, `[[`, "treated")), nfolds, length(lambda.full$treated)))
+    cv.mean1 <- colMeans(matrix(unlist(lapply(cv.list, `[[`, "treated")),
+                                nrow = nfolds,
+                                ncol = length(lambda.full$treated),
+                                byrow = TRUE))
     idx.min1 <- which.min(cv.mean1)
     lambda.min1 <- lambda.full[["treated"]][idx.min1]
   }

--- a/r-package/balnet/tests/testthat/test_cv.balnet.R
+++ b/r-package/balnet/tests/testthat/test_cv.balnet.R
@@ -86,14 +86,11 @@ test_that("cv.balnet has not changed", {
 
   expect_equal(
     coef(fit),
-    structure(list(control = new("dgCMatrix", i = 0:3, p = c(0L,
-    4L), Dim = c(4L, 1L), Dimnames = list(c("(Intercept)", "X1",
-    "X2", "X3"), NULL), x = c(0.680645954386779, 0.0964925117386255,
-    0.210324237163201, 0.145107291953369), factors = list()), treated = new("dgCMatrix",
-        i = 0:3, p = c(0L, 4L), Dim = c(4L, 1L), Dimnames = list(
-            c("(Intercept)", "X1", "X2", "X3"), NULL), x = c(-0.681102012267433,
-        -0.0496225138747977, -0.149449789859248, -0.237897822417655
-        ), factors = list())), class = "coef.balnet.contrast")
+    structure(list(control = new("dgCMatrix", i = 0L, p = 0:1, Dim = c(4L,
+1L), Dimnames = list(c("(Intercept)", "X1", "X2", "X3"), NULL),
+    x = 0.652873281422005, factors = list()), treated = new("dgCMatrix",
+    i = 0L, p = 0:1, Dim = c(4L, 1L), Dimnames = list(c("(Intercept)",
+    "X1", "X2", "X3"), NULL), x = -0.652873281422005, factors = list())), class = "coef.balnet.contrast")
   )
 
   expect_equal(


### PR DESCRIPTION
cv.balnet was aggregating per-fold losses incorrectly (row/column mismatch in the fold × λ matrix). This PR fixes that.